### PR TITLE
Changed requirement to py-cord

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2
-pycord
+py-cord
 requests
 pytz
 dnspython


### PR DESCRIPTION
Changed library to `py-cord` instead of `discord.py` in order to utilize slash commands