### PR TITLE
Switched library to py-cord

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2
-discord
+py-cord
 requests
 pytz
 dnspython


### PR DESCRIPTION
Changed requirement from `discord.py` to `py-cord` in order to access slash commands