### PR TITLE
Convert verify command to slash command

### DIFF
--- a/Cogs/verification.py
+++ b/Cogs/verification.py
@@ -19,24 +19,25 @@ class Verification(commands.Cog):
         self.bot=bot
 ###########################################################################
     @discord.slash_command(name='verify', description="Verifies a user for access to locked channels")
-    async def verify(self, ctx, email, firstname, lastname):
+    async def verify(self, ctx, email, fullname):
         if(discord.utils.get(ctx.author.roles, name = "Verified") != None): # We could have this check the DB, would maybe cause issues with manually verified folks.
             await ctx.respond(embed = discord.Embed(title = "You are already verified!", description = "*If you believe this is an error, please message a board member*", color = discord.Color.red()))
             return
         
+        await ctx.defer()
+
         #Trims parameters
         email = email.strip()
-        firstname = firstname.strip()
-        lastname = lastname.strip()
+        fullname = fullname.strip()
 
         verified, message, color = verify_user(ctx.author.id, email)
 
         if verified: #Prompts user to enter name to finish verifying
-            author = ctx.author
+            #author = ctx.author
 
-            insert_verified_user_record(author.id, email, firstname + " " + lastname)
+            insert_verified_user_record(ctx.author.id, email, fullname)
             role = discord.utils.get(ctx.guild.roles, name = "Verified")
-            await author.add_roles(role)
+            await ctx.author.add_roles(role)
             await ctx.respond(embed = discord.Embed(title = f"{ctx.author}, you have been successfully verified!", color = color))
 
         else: #Verification errored, or they have a verification record already in the DB, but lost the role

--- a/Cogs/verification.py
+++ b/Cogs/verification.py
@@ -33,7 +33,6 @@ class Verification(commands.Cog):
         verified, message, color = verify_user(ctx.author.id, email)
 
         if verified: #Prompts user to enter name to finish verifying
-            #author = ctx.author
 
             insert_verified_user_record(ctx.author.id, email, fullname)
             role = discord.utils.get(ctx.guild.roles, name = "Verified")

--- a/UWVerificationHelp.json
+++ b/UWVerificationHelp.json
@@ -12,7 +12,7 @@
 
     "full": {
         "verification":{
-            "!verify email@wisc.edu": "Starts verification process to access server features, must have valid @wisc.edu email (i.e: !verify jSmith@wisc.edu)"
+            "/verify email@wisc.edu firstName lastName": "Starts verification process to access server features, must have valid @wisc.edu email (i.e: /verify jSmith@wisc.edu John Smith)"
             ,"!whois UserName#0000": "Returns the email address and name of the specified verified discord user. Only accessible to Board Members, Game Officers, and Mods"
             ,"!manualverify UserName#0000 email@wisc.edu full_name": "Manually verifies the user with the information provided. Only accessible to Board Members, Game Officers, and Mods"
             ,"!del_verify UserName#0000 (or) !del_verify email@wisc.edu" : "Manually deletes a user's verification record. Only accessible to Board Members, Game Officers, and Mods"

--- a/UWVerificationHelp.json
+++ b/UWVerificationHelp.json
@@ -12,7 +12,7 @@
 
     "full": {
         "verification":{
-            "/verify email@wisc.edu firstName lastName": "Starts verification process to access server features, must have valid @wisc.edu email (i.e: /verify jSmith@wisc.edu John Smith)"
+            "/verify email@wisc.edu fullName": "Starts verification process to access server features, must have valid @wisc.edu email (i.e: /verify jSmith@wisc.edu John Smith)"
             ,"!whois UserName#0000": "Returns the email address and name of the specified verified discord user. Only accessible to Board Members, Game Officers, and Mods"
             ,"!manualverify UserName#0000 email@wisc.edu full_name": "Manually verifies the user with the information provided. Only accessible to Board Members, Game Officers, and Mods"
             ,"!del_verify UserName#0000 (or) !del_verify email@wisc.edu" : "Manually deletes a user's verification record. Only accessible to Board Members, Game Officers, and Mods"


### PR DESCRIPTION
Switched the main `!verify` command to slash commands, removing some of the async timing logic that was needed for users to enter their name. They can now do it all in 1 command instead of entering multiple