### PR TITLE
Switch misc commands to slash

### DIFF
--- a/Cogs/Helpers/types.py
+++ b/Cogs/Helpers/types.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+# Enum for Help command
+class HelpTypes(Enum):
+    Verification = 'Verification'
+    Misc = "Misc"
+    Settings = "Settings"
+    Website = "WEBSITE"

--- a/Cogs/misc.py
+++ b/Cogs/misc.py
@@ -60,18 +60,12 @@ class Misc(commands.Cog):
     @discord.slash_command(name = "purge", debug_guilds=[887366492730036276]) #Clears previous x amount of messages (x between 1 & 50)
     @commands.has_guild_permissions(manage_messages = True)
     async def purge(self, ctx, limit: discord.Option(discord.SlashCommandOptionType.integer, "Amount of messages to clear (1-50)", required = True)):
-        # Currently disabled b/c ctx.message.channel no longer exists and can't find alternative
-        await ctx.respond(embed = discord.Embed(title = "Command currently disabled")) 
-        return
-        
         if limit > 50 or limit < 1:
             await ctx.respond(embed = discord.Embed(title = "Only 1 to 50 messages can be cleared at a time"))
             return
         try:
-            await ctx.message.channel.purge(limit = (limit + 1)) #To account for the deletion message itself
-            msg = await ctx.respond(embed = discord.Embed(title = f"Previous {limit} messages deleted"))
-            await asyncio.sleep(2)
-            await msg.delete()
+            await ctx.channel.purge(limit = (limit + 1))
+            await ctx.respond(embed = discord.Embed(title = f"Previous {limit} messages deleted"))
         except discord.Forbidden:
            await ctx.respond(embed = discord.Embed(title = "I do not have enough permissions to do this, please change my role permissions!"))
         except Exception as e:

--- a/Cogs/misc.py
+++ b/Cogs/misc.py
@@ -2,45 +2,46 @@ import asyncio
 import json
 import discord
 from discord.ext import commands
+from Cogs.Helpers.types import HelpTypes
 
 class Misc(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 ###########################################################################
-    @commands.command(name = "help", aliases = ["h", "helpinfo"]) #Help messages
-    async def help(self, ctx, type = None):
-        if type == None:
+    @discord.slash_command(name = "help", debug_guilds=[887366492730036276]) #Help messages
+    async def help(self, ctx, category: discord.Option(HelpTypes, "Enter the type of command", required = False)):
+        if category == None: # Short version
             with open("UWVerificationHelp.json", "r") as helpFile:
                 data = json.load(helpFile)
             data = data['short']
 
             embed = discord.Embed(title = "Help Menu\t\tPrefix: !", color=discord.Color.green())
-            embed.set_author(name = "Type `!help [category]` to see an in-depth guide for the inputed category")
+            embed.set_author(name = "Type `/help [category]` to see an in-depth guide for the inputed category")
             embed.set_footer(text = "Created by DMLooter#4251 & PureCache#0001")
             embed.add_field(name = "Verification Commands", value = data["Verification"], inline = False)
             embed.add_field(name = "Website Commands", value = data["Website"], inline = False)
             embed.add_field(name = "Miscellaneous Commands", value = data["Misc"], inline = False)
 
-        else:
+        else: # Full version
             with open("UWVerificationHelp.json", "r") as helpFile:
                 data = json.load(helpFile)
 
             data = data["full"]
-            data = data[type.lower()]
-            embed = discord.Embed(title = (f"{type} commands:"), color = discord.Color.green())
+            data = data[category.value.lower()]
+            embed = discord.Embed(title = (f"{category} commands:"), color = discord.Color.green())
             embed.set_author(name=("Key: (required) [optional]"))
             embed.set_footer(text = "Created by DMLooter#4251 & PureCache#0001")
 
             for key in data:
                 embed.add_field(name = (f"`{key}`"), value = data[key], inline = False)
 
-        await ctx.send(embed=embed)
+        await ctx.respond(embed=embed)
 
     @help.error
     async def clear_error(self, ctx, error):
-        await ctx.send(embed = discord.Embed(title = "This category does not exist! Make sure you spelled it correctly, use `!help` to see a short list of all types"))
+        await ctx.respond(embed = discord.Embed(title = "This category does not exist! Make sure you spelled it correctly, use `/help` to see a short list of all types"))
 ###########################################################################
-    @commands.command(name = "ping")
+    @discord.slash_command(name = "ping", debug_guilds=[887366492730036276])
     async def ping(self, ctx):
         try:
             embed = discord.Embed(title = "**Ping :ping_pong:**", color = discord.Color.blurple())
@@ -52,34 +53,39 @@ class Misc(commands.Cog):
                 latencyList.append(self.bot.latency)
 
             embed.add_field(name = "Average", value=f"{round((sum(latencyList)/tests) * 1000, 2)} ms", inline = False)
-            await ctx.send(embed = embed)
+            await ctx.respond(embed = embed)
         except Exception as e:
             print(e)
 ###########################################################################
-    @commands.command(name = "purge", aliases = ["clear", "delete"]) #Clears previous x amount of messages (x between 1 & 50)
+    @discord.slash_command(name = "purge", debug_guilds=[887366492730036276]) #Clears previous x amount of messages (x between 1 & 50)
     @commands.has_guild_permissions(manage_messages = True)
-    async def purge(self, ctx, limit: int):
+    async def purge(self, ctx, limit: discord.Option(discord.SlashCommandOptionType.integer, "Amount of messages to clear (1-50)", required = True)):
+        # Currently disabled b/c ctx.message.channel no longer exists and can't find alternative
+        await ctx.respond(embed = discord.Embed(title = "Command currently disabled")) 
+        return
+        
         if limit > 50 or limit < 1:
-            await ctx.send(embed = discord.Embed(title = "Only 1 to 50 messages can be cleared at a time"))
+            await ctx.respond(embed = discord.Embed(title = "Only 1 to 50 messages can be cleared at a time"))
             return
         try:
-            await ctx.message.channel.purge(limit = (limit + 1))
-            msg = await ctx.send(embed = discord.Embed(title = f"Previous {limit} messages deleted"))
+            await ctx.message.channel.purge(limit = (limit + 1)) #To account for the deletion message itself
+            msg = await ctx.respond(embed = discord.Embed(title = f"Previous {limit} messages deleted"))
             await asyncio.sleep(2)
             await msg.delete()
         except discord.Forbidden:
-           await ctx.send(embed = discord.Embed(title = "I do not have enough permissions to do this, please change my role permissions!"))
-
+           await ctx.respond(embed = discord.Embed(title = "I do not have enough permissions to do this, please change my role permissions!"))
+        except Exception as e:
+            print(e)
     @purge.error
     async def clear_error(self, ctx, error):
         if isinstance(error,commands.MissingPermissions):
-            await ctx.send(embed = discord.Embed(title = "You do not have permission to use this command"))
+            await ctx.respond(embed = discord.Embed(title = "You do not have permission to use this command"))
         elif isinstance(error, commands.BadArgument):
-            await ctx.send(embed = discord.Embed(title = "Parameter must be an integer between 1 and 50"))
+            await ctx.respond(embed = discord.Embed(title = "Parameter must be an integer between 1 and 50"))
         elif isinstance(error,commands.MissingRequiredArgument):
-            await ctx.send(embed = discord.Embed(title = "Missing required argument, use !purge x"))
+            await ctx.respond(embed = discord.Embed(title = "Missing required argument, use !purge x"))
 ###########################################################################
-    @commands.command(name = "botinfo", aliases = ["info"]) #Displays informaton about the bot
+    @discord.slash_command(name = "botinfo", debug_guilds=[887366492730036276]) #Displays information about the bot
     async def botinfo(self, ctx):
         infoDict = {
                 "Created": "September 2021"
@@ -88,11 +94,10 @@ class Misc(commands.Cog):
                 }
         infoEmbed = discord.Embed(title = "UW Verification Bot Information", color = discord.Color.orange())
         infoEmbed.set_author(name = "Created by DMLooter#4251 & PureCache#0001")
-        infoEmbed.set_footer(text = "Prefix: !")
 
         for key in infoDict:
             infoEmbed.add_field(name = key,value = infoDict[key], inline = False)
-        await ctx.send(embed = infoEmbed)
+        await ctx.respond(embed = infoEmbed)
 ###########################################################################
 def setup(bot):
     bot.add_cog(Misc(bot))

--- a/UWVerification.py
+++ b/UWVerification.py
@@ -117,7 +117,7 @@ async def on_member_remove(member):
 @bot.event #Generic error handling
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
-        await ctx.send(embed=discord.Embed(title="Command not found! Use `!help` for a list of all commands"))
+        await ctx.send(embed=discord.Embed(title="Command not found! Use `/help` for a list of all commands"))
     elif isinstance(error, commands.CommandOnCooldown):
         await ctx.send(embed=discord.Embed(title="You are currently on cooldown!"))
     elif isinstance(error, commands.BotMissingPermissions):

--- a/UWVerificationHelp.json
+++ b/UWVerificationHelp.json
@@ -19,8 +19,8 @@
             ,"/unverify email email@wisc.edu": "Manually deletes any verification record containing the specified email (freeing it to be reused). Only accessible to Board Members, Game Officers, and Mods"
         },
         "misc":{
-            "!help": "Displays help menu"
-            ,"!ping": "Displays bot's current ping"
+            "/help [category]": "Displays help menu"
+            ,"/ping": "Displays bot's current ping"
         },
         "settings":{
             "!setwelcomemsg [message]": "Sets the bot message for when someone joins the server. Type %s where you want the user to be mentioned, or leave message blank to set to default (Requires `Manage Server` permission)"


### PR DESCRIPTION
-Converted misc commands to slash types.
-Purge had to be disabled for now because `ctx.message.channel` no longer exists, and cannot find a current alternative for it. Will require further research
-Created a new Helper file for enums. This will be used to slowly convert all the error messages and any other place where an enum would be cleaner. 